### PR TITLE
chore: rename master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,4 +27,4 @@ npx envinfo --system --binaries
 **Pull requests**
 
 Pull requests are welcome! If you would like to help us fix this bug, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -36,5 +36,5 @@ Yes/No.
 
 <!--
 Pull requests are welcome! If you would like to help us add this feature, please check our
-[contributions guidelines](../blob/master/CONTRIBUTING.md).
+[contributions guidelines](../blob/main/CONTRIBUTING.md).
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ Example: Another solution would be [...]
 
 Please add a `x` inside each checkbox:
 
-- [ ] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
+- [ ] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
 - [ ] The status checks are successful (continuous integration). Those can be seen below.
 
 **A picture of a cute animal (not mandatory but encouraged)**

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: release-please
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   # Ensure GitHub actions are not run twice for same commits
   push:
-    branches: [master]
+    branches: [main]
     tags: ['*']
   pull_request:
     types: [opened, synchronize, reopened]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,6 @@ After submitting the pull request, please make sure the Continuous Integration c
 ## Releasing
 
 1. Merge the release PR
-2. Switch to the default branch `git checkout master`
+2. Switch to the default branch `git checkout main`
 3. Pull latest changes `git pull`
 4. Publish the package `npm publish`

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   extends: ['github>netlify/renovate-config:default'],
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
-  masterIssue: true,
+  dependencyDashboard: true,
   automerge: false,
   packageRules: [
     {


### PR DESCRIPTION
Update any `master` references to `main`

I'll follow up with another PR to https://github.com/netlify/node-template