### PR TITLE
chore: move workspaces logic

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,28 +1,6 @@
 'use strict'
 
-const mapWorkspaces = require('@npmcli/map-workspaces')
-
-const getWorkspaceInfo = async function ({ rootPackageJson, projectDir, rootDir }) {
-  if (!rootPackageJson.workspaces) {
-    return
-  }
-
-  const workspacesMap = await mapWorkspaces({
-    cwd: rootDir || projectDir,
-    pkg: rootPackageJson,
-  })
-
-  const packages = [...workspacesMap.values()]
-  // The provided project dir is a workspace package
-  const isWorkspace = packages.find((path) => projectDir === path)
-
-  // The project dir is a collection of workspaces itself
-  const isRoot = !rootDir
-
-  if (isWorkspace || isRoot) {
-    return { isRoot, packages }
-  }
-}
+const { getWorkspaceInfo } = require('./workspaces')
 
 const buildInfo = async function (context) {
   const workspaceInfo = await getWorkspaceInfo(context)

--- a/src/workspaces.js
+++ b/src/workspaces.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const mapWorkspaces = require('@npmcli/map-workspaces')
+
+const getWorkspaceInfo = async function ({ rootPackageJson, projectDir, rootDir }) {
+  if (!rootPackageJson.workspaces) {
+    return
+  }
+
+  const workspacesMap = await mapWorkspaces({
+    cwd: rootDir || projectDir,
+    pkg: rootPackageJson,
+  })
+
+  const packages = [...workspacesMap.values()]
+  // The provided project dir is a workspace package
+  const isWorkspace = packages.find((path) => projectDir === path)
+
+  // The project dir is a collection of workspaces itself
+  const isRoot = !rootDir
+
+  if (isWorkspace || isRoot) {
+    return { isRoot, packages }
+  }
+}
+
+module.exports = { getWorkspaceInfo }


### PR DESCRIPTION
This is a simple refactor ahead of #31 to move the `workspace` logic out of the `core` module into it's own file.