### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '*'
+          check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [8.17.0, 15.x]
+        node-version: [8.17.0, '*']
         exclude:
           - os: macOS-latest
             node-version: 8.17.0
@@ -27,11 +27,12 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
       - name: Install dependencies
         run: npm ci
       - name: Linting
         run: npm run format:ci
-        if: "${{ matrix.node-version == '15.x' }}"
+        if: "${{ matrix.node-version == '*' }}"
       - name: Tests
         run: npm run test:ci
       - name: Get test coverage flags


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.