### PR TITLE
chore!: drop support for Node.js 8

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [8.17.0, '*']
+        node-version: ['10.X', '*']
         exclude:
           - os: macOS-latest
-            node-version: 8.17.0
+            node-version: '10.X'
           - os: windows-latest
-            node-version: 8.17.0
+            node-version: '10.X'
       fail-fast: false
     steps:
       - name: Git checkout

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nyc": "^15.0.0"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=10.18.0"
   },
   "dependencies": {
     "@netlify/framework-info": "^4.1.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,8 +6,6 @@
   automerge: true,
   packageRules: [
     {
-      // Those cannot be upgraded to a major version until we drop support for Node 8
-      packageNames: ['ava', 'execa', 'get-bin-path', 'read-pkg', 'yargs'],
       major: {
         enabled: false,
       },


### PR DESCRIPTION
Preparation for https://github.com/netlify/build-info/pull/65 and follow up on https://github.com/netlify/framework-info/pull/258