### PR TITLE
chore!: drop Node.js 10 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "nyc": "^15.0.0"
       },
       "engines": {
-        "node": ">=10.18.0"
+        "node": ">=12.16.3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nyc": "^15.0.0"
   },
   "engines": {
-    "node": ">=10.18.0"
+    "node": ">=12.16.3"
   },
   "dependencies": {
     "@netlify/framework-info": "^5.5.0",


### PR DESCRIPTION
So we can merge https://github.com/netlify/build-info/pull/108

This PR uses the same version as https://github.com/netlify/buildbot/blob/b7aeb2675f82192daa8545b22bebab9c3b179d0e/Dockerfile#L7

@ehmicky can you confirm it's sufficient for `get-bin-path`. The minimal Node.js version for `get-bin-path` is `12.20.0`.

Also cc @JGAntunes to verify we can drop Node.js 10 support as this utility always runs using the system's Node.js version