### PR TITLE
chore: simplify `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,15 +4,5 @@
   semanticCommits: true,
   dependencyDashboard: true,
   automerge: true,
-  // Those cannot be upgraded until we drop support for Node 10
-  packageRules: [
-    {
-      matchPackageNames: ['yargs'],
-      allowedVersions: '<17',
-    },
-    {
-      matchPackageNames: ['read-pkg'],
-      allowedVersions: '<6',
-    },
-  ],
+  packageRules: [],
 }


### PR DESCRIPTION
This simplifies `renovate.json5` thanks to https://github.com/netlify/renovate-config/pull/64.