### PR TITLE
chore!: drop support for Node 10

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: ['10.X', '*']
+        node-version: ['12.20.0', '*']
         exclude:
           - os: macOS-latest
-            node-version: '10.X'
+            node-version: '12.20.0'
           - os: windows-latest
-            node-version: '10.X'
+            node-version: '12.20.0'
       fail-fast: false
     steps:
       - name: Git checkout

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nyc": "^15.0.0"
   },
   "engines": {
-    "node": ">=10.18.0"
+    "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
   },
   "dependencies": {
     "@netlify/framework-info": "^5.11.0",


### PR DESCRIPTION
Fixes https://github.com/netlify/build-info/issues/180

This drops Node 10 support.

I will also fix the branch protection rule right before merging this.